### PR TITLE
Fix for long custom statuses in status selector

### DIFF
--- a/phoenix-bundle/base.css
+++ b/phoenix-bundle/base.css
@@ -4291,7 +4291,7 @@ pre {
   pointer-events: none;
   top: 0;
   display: flex;
-  flex-flow: row wrap;
+  flex-flow: row nowrap;
   justify-content: space-between;
 }
 


### PR DESCRIPTION
Currently the custom status selector (.layer-v9HyYc[style*="; bottom: 5"][id*="popout_"] .menu-Sp6bN1 .itemBase-1Qj4z6:nth-child(7)) is set to wrap the text, which causes the clear button to get pushed to the next line assuming the status is long enough (as seen in this image: https://cdn.discordapp.com/attachments/600434466866987022/667507552950550563/unknown.png). By setting the flex-flow property here to row nowrap, it causes it to not wrap anymore and thus also doesn't push the clear button to a seperate line (as seen in this image: https://cdn.discordapp.com/attachments/600434466866987022/667507613323231267/unknown.png)