### PR TITLE
Add roundness variable to server folder background and server borders

### DIFF
--- a/phoenix-bundle/base.css
+++ b/phoenix-bundle/base.css
@@ -1058,6 +1058,7 @@ color: var(--dnd) !important;
   border: 2px solid var(--main-color);
   box-sizing: border-box;
   transition: all 200ms ease-in-out;
+  border-radius: var(--roundness);
 }
 
 #app-mount .acronym-2mOFsV:hover {
@@ -1114,6 +1115,7 @@ border-color: 2px dashed rgba(255, 255, 255, .1);
 #app-mount .folder-21wGz3,
   #app-mount .expandedFolderBackground-2sPsd- {
     background-color: transparent;
+    border-radius: var(--roundness);
   }
 
 #app-mount .expandedFolderBackground-2sPsd-::before {


### PR DESCRIPTION
Currently, the server borders/server folder background don't respect the roundness user variable, which can cause it to look really off if the user sets their own roundness. With this change it'll respect the roundness so it looks a lot better in general

Without roundness variable 
![image](https://user-images.githubusercontent.com/59900178/72759789-04a2b180-3bd7-11ea-8ed0-94034cf9cfb4.png)

With roundness variable
![image](https://user-images.githubusercontent.com/59900178/72759800-0f5d4680-3bd7-11ea-94af-99d7fefd1e37.png)

