### PR TITLE
FIX premium with and without banners [Phoenix Bundle]

### DIFF
--- a/phoenix-bundle/base.css
+++ b/phoenix-bundle/base.css
@@ -3439,6 +3439,15 @@ pre {
   width: 80px !important;
 }
 
+/* fix premium no banner */
+#app-mount div.avatarPositionPremiumBanner-2nq2Fy .wrapper-1VLyxH[style*="height: 80px"] rect[mask*="svg-mask-status"],
+#app-mount div.avatarPositionPremiumBanner-2nq2Fy .wrapper-1VLyxH[style*="height: 80px"] foreignobject + svg rect
+#app-mount div.avatarPositionPremiumNoBanner-nWzERs .wrapper-1VLyxH[style*="height: 80px"] rect[mask*="svg-mask-status"],
+#app-mount div.avatarPositionPremiumNoBanner-nWzERs .wrapper-1VLyxH[style*="height: 80px"] foreignobject + svg rect {
+    height: 16px !important;
+    width: 16px !important;
+}
+
 #app-mount .wrapper-1VLyxH[style*="height: 120px"] rect[mask*="svg-mask-status"],
 #app-mount .wrapper-1VLyxH[style*="height: 120px"] foreignObject+svg rect {
   height: 120px !important;


### PR DESCRIPTION
Previously without this fix, the indicators would look like this.

![image](https://user-images.githubusercontent.com/17491233/193494415-9a855414-bc37-4e87-abd9-f31cb774a12c.png)

![image](https://user-images.githubusercontent.com/17491233/193494426-4d9eeb6d-d664-4102-a857-5a59bbfdbb4c.png)

Now they are fixed with this small change.

![image](https://user-images.githubusercontent.com/17491233/193494461-6dac13e6-484f-49b0-a356-4e8dcb3c6edd.png)

